### PR TITLE
Fix broken discord hyperlink

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 		<span> This is the main and largest part of the community, full of screenshots, tools, themes, guides and more! </span>
 	</p>
 	<p>
-		<a href='https://discord.gg/GMGsRz5REb'>discord</a>
+		<a href='https://discord.gg/TnJ4h5K'>discord</a>
 		<span> Here you can chat all you want about desktop customization, Unix, programming, and general topics with like-minded people. </span>
 	</p>
 	<p>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 		<span> This is the main and largest part of the community, full of screenshots, tools, themes, guides and more! </span>
 	</p>
 	<p>
-		<a href='https://discord.gg/TnJ4h5K'>discord</a>
+		<a href='https://discord.gg/unixporn'>discord</a>
 		<span> Here you can chat all you want about desktop customization, Unix, programming, and general topics with like-minded people. </span>
 	</p>
 	<p>


### PR DESCRIPTION
The current discord link on the website is invalid. In face of the reddit blackout protests, some still want to be able to see linux rices and the discord is the second best way. 